### PR TITLE
Unify expression accessing reference values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Improved
 
 - Expression adapting ([#37](https://github.com/mrahhal/MR.EntityFrameworkCore.KeysetPagination/issues/37) by [@mrahhal](https://github.com/mrahhal))
+- Unify expression accessing reference values ([#42](https://github.com/mrahhal/MR.EntityFrameworkCore.KeysetPagination/pull/42) by [@mrahhal](https://github.com/mrahhal))
 
 [**Full diff**](https://github.com/mrahhal/MR.EntityFrameworkCore.KeysetPagination/compare/v1.2.0...HEAD)
 

--- a/src/MR.EntityFrameworkCore.KeysetPagination/KeysetFilterPredicateStrategy.cs
+++ b/src/MR.EntityFrameworkCore.KeysetPagination/KeysetFilterPredicateStrategy.cs
@@ -154,7 +154,7 @@ internal class KeysetFilterPredicateStrategyMethod1 : KeysetFilterPredicateStrat
 {
 	public static readonly KeysetFilterPredicateStrategyMethod1 Instance = new();
 
-	public static bool EnableFirstColPredicateOpt = false;
+	public static bool EnableFirstColPredicateOpt = true;
 
 	private KeysetFilterPredicateStrategyMethod1()
 	{

--- a/src/MR.EntityFrameworkCore.KeysetPagination/KeysetFilterPredicateStrategy.cs
+++ b/src/MR.EntityFrameworkCore.KeysetPagination/KeysetFilterPredicateStrategy.cs
@@ -34,11 +34,18 @@ internal abstract class KeysetFilterPredicateStrategy : IKeysetFilterPredicateSt
 		where T : class
 	{
 		var referenceValues = GetValues(columns, reference);
+		var referenceValueExpressions = new Expression<Func<object>>[referenceValues.Count];
+		for (var i = 0; i < referenceValues.Count; i++)
+		{
+			var referenceValue = referenceValues[i];
+			Expression<Func<object>> referenceValueExpression = () => referenceValue;
+			referenceValueExpressions[i] = referenceValueExpression;
+		}
 
 		// entity =>
 		var param = Expression.Parameter(typeof(T), "entity");
 
-		var finalExpression = BuildExpressionCore(columns, direction, referenceValues, param);
+		var finalExpression = BuildExpressionCore(columns, direction, referenceValueExpressions, param);
 
 		return Expression.Lambda<Func<T, bool>>(finalExpression, param);
 	}
@@ -46,7 +53,7 @@ internal abstract class KeysetFilterPredicateStrategy : IKeysetFilterPredicateSt
 	protected abstract Expression BuildExpressionCore<T>(
 		IReadOnlyList<KeysetColumn<T>> columns,
 		KeysetPaginationDirection direction,
-		List<object> referenceValues,
+		IReadOnlyList<Expression<Func<object>>> referenceValueExpressions,
 		ParameterExpression param)
 		where T : class;
 
@@ -147,7 +154,7 @@ internal class KeysetFilterPredicateStrategyMethod1 : KeysetFilterPredicateStrat
 {
 	public static readonly KeysetFilterPredicateStrategyMethod1 Instance = new();
 
-	public static bool EnableFirstColPredicateOpt = true;
+	public static bool EnableFirstColPredicateOpt = false;
 
 	private KeysetFilterPredicateStrategyMethod1()
 	{
@@ -156,7 +163,7 @@ internal class KeysetFilterPredicateStrategyMethod1 : KeysetFilterPredicateStrat
 	protected override Expression BuildExpressionCore<T>(
 		IReadOnlyList<KeysetColumn<T>> columns,
 		KeysetPaginationDirection direction,
-		List<object> referenceValues,
+		IReadOnlyList<Expression<Func<object>>> referenceValueExpressions,
 		ParameterExpression param)
 		where T : class
 	{
@@ -207,9 +214,7 @@ internal class KeysetFilterPredicateStrategyMethod1 : KeysetFilterPredicateStrat
 				var isInnerLastOperation = j + 1 == innerLimit;
 				var column = columns[j];
 				var memberAccess = column.MakeAccessExpression(param);
-				var referenceValue = referenceValues[j];
-				Expression<Func<object>> referenceValueFunc = () => referenceValue;
-				var referenceValueExpression = referenceValueFunc.Body;
+				var referenceValueExpression = referenceValueExpressions[j].Body;
 
 				if (firstMemberAccessExpression == null)
 				{
@@ -277,7 +282,7 @@ internal class KeysetFilterPredicateStrategyMethod2 : KeysetFilterPredicateStrat
 	protected override Expression BuildExpressionCore<T>(
 		IReadOnlyList<KeysetColumn<T>> columns,
 		KeysetPaginationDirection direction,
-		List<object> referenceValues,
+		IReadOnlyList<Expression<Func<object>>> referenceValueExpressions,
 		ParameterExpression param)
 		where T : class
 	{
@@ -320,9 +325,7 @@ internal class KeysetFilterPredicateStrategyMethod2 : KeysetFilterPredicateStrat
 				var isInnerLastOperation = j + 1 == innerLimit;
 				var column = columns[j];
 				var memberAccess = column.MakeAccessExpression(param);
-				var referenceValue = referenceValues[j];
-				Expression<Func<object>> referenceValueFunc = () => referenceValue;
-				var referenceValueExpression = referenceValueFunc.Body;
+				var referenceValueExpression = referenceValueExpressions[j].Body;
 
 				BinaryExpression innerExpression;
 				if (!isInnerLastOperation)


### PR DESCRIPTION
This PR unifies accessing expressions of reference values which lead to decreased number of generated sql parameters.

Here's an example of the generated sql parameters of the same query with a two columns keyset.
Before:
```
[Parameters=[@__p_3='10', @__p_0='False', @__p_1='False', @__p_2='21']
```

After:
```
[Parameters=[@__p_2='10', @__p_0='False', @__p_1='21']
```